### PR TITLE
feature/rcg-change-class-inheritance-of-model-event

### DIFF
--- a/app/models/wassenger_client/event.rb
+++ b/app/models/wassenger_client/event.rb
@@ -1,21 +1,23 @@
 # frozen_string_literal: true
 
 module WassengerClient
-  class Event < WassengerClient::Client
-    def message
-      WassengerClient::Message.new(data)
-    end
+  class Event < OpenStruct
+    class << self
 
-    def sent_message?
-      event == 'message:out:sent'
-    end
+      def message
+        WassengerClient::Message.new(data)
+      end
 
-    def failed_message?
-      event == 'message:out:failed'
-    end
+      def sent_message?
+        event == 'message:out:sent'
+      end
 
-    def in_new?
-      event == 'message:in:new'
-    end
+      def failed_message?
+        event == 'message:out:failed'
+      end
+
+      def in_new?
+        event == 'message:in:new'
+      end
   end
 end


### PR DESCRIPTION
change class inheritance of the model event to now be a OpenStruct